### PR TITLE
support for custom headers and nested data payloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ var obj = {
     uploadUrl,
     fileName,
     mimeType,
+    headers,
     data: {
         // whatever properties you wish to send in the request
         // along with the uploaded file


### PR DESCRIPTION
This adds support for:
1) Custom headers
2) Nested data

I am not sure how much longer this will be relevant given https://github.com/facebook/react-native/pull/1357 but I needed these for a project. Perhaps they will be useful to others.

Also I am not sure about how best to handle nested data. My implementation simply converts the property to a JSON string and sends it to the server which will hopefully parse it accordinly. This is surely not the "correct" way. 
