### PR TITLE
Add size and format options when uploading an asset library image

### DIFF
--- a/RCTFileTransfer.m
+++ b/RCTFileTransfer.m
@@ -51,10 +51,18 @@ RCT_EXPORT_METHOD(upload:(NSDictionary *)input callback:(RCTResponseSenderBlock)
   [library assetForURL:assetUrl resultBlock:^(ALAsset *asset) {
 
     ALAssetRepresentation *rep = [asset defaultRepresentation];
+    UIImage *image;
+    NSString *size = input[@"size"];
 
-    CGImageRef fullScreenImageRef = [rep fullScreenImage];
-    UIImage *image = [UIImage imageWithCGImage:fullScreenImageRef];
-    NSData *fileData = UIImagePNGRepresentation(image);
+    if ([size isEqualToString:@"full"]) {
+      CGImageRef imageRef = [rep fullResolutionImage];
+      image = [UIImage imageWithCGImage:imageRef scale:[rep scale] orientation:(UIImageOrientation)[rep orientation]];
+    } else {
+      CGImageRef fullScreenImageRef = [rep fullScreenImage];
+      image = [UIImage imageWithCGImage:fullScreenImageRef];
+    }
+
+    NSData *fileData = UIImageJPEGRepresentation(image, 1);
 
     [self sendData:fileData withOptions:input callback:callback];
 

--- a/RCTFileTransfer.m
+++ b/RCTFileTransfer.m
@@ -53,6 +53,7 @@ RCT_EXPORT_METHOD(upload:(NSDictionary *)input callback:(RCTResponseSenderBlock)
     ALAssetRepresentation *rep = [asset defaultRepresentation];
     UIImage *image;
     NSString *size = input[@"size"];
+    NSString *format = input[@"format"];
 
     if ([size isEqualToString:@"full"]) {
       CGImageRef imageRef = [rep fullResolutionImage];
@@ -62,7 +63,12 @@ RCT_EXPORT_METHOD(upload:(NSDictionary *)input callback:(RCTResponseSenderBlock)
       image = [UIImage imageWithCGImage:fullScreenImageRef];
     }
 
-    NSData *fileData = UIImageJPEGRepresentation(image, 1);
+    NSData *fileData;
+    if ([format isEqualToString:@"JPEG"]) {
+      fileData = UIImageJPEGRepresentation(image, 1);
+    } else {
+      fileData = UIImagePNGRepresentation(image);
+    }
 
     [self sendData:fileData withOptions:input callback:callback];
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ var { NativeModules } = require('react-native');
 var obj = {
     uri, // either an 'assets-library' url (for files from photo library) or an image dataURL
     size, // either 'screen' (default) or 'full', only applies to asset library uploads
+    format, // either 'PNG' (default) or 'JPEG', only applies to asset library uploads
     uploadUrl,
     fileName,
     mimeType,

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ When you properly add the `RCTFileTransfer.m` file to your xcode project you may
 var { NativeModules } = require('react-native');
 var obj = {
     uri, // either an 'assets-library' url (for files from photo library) or an image dataURL
+    size, // either 'screen' (default) or 'full', only applies to asset library uploads
     uploadUrl,
     fileName,
     mimeType,


### PR DESCRIPTION
I had a need to upload original full resolution images as JPEGs, so added options to do this, but left the defaults as screen resolution PNG for backward compatibility.
