### PR TITLE
Allow users to use PUT or POST requests

### DIFF
--- a/RCTFileTransfer.m
+++ b/RCTFileTransfer.m
@@ -101,8 +101,10 @@ RCT_EXPORT_METHOD(upload:(NSDictionary *)input callback:(RCTResponseSenderBlock)
   NSString *mimeType = input[@"mimeType"];
   NSString *uploadUrl = input[@"uploadUrl"];
   NSString *fileKey = input[@"fileKey"];
+  NSString *HTTPMethod = input[@"HTTPMethod"];
     
   if (!fileKey) fileKey = @"file";
+  if (!HTTPMethod) HTTPMethod = @"POST";
 
   NSDictionary* requestData = [input objectForKey:@"data"];
   NSDictionary* requestHeaders = [input objectForKey:@"headers"];
@@ -123,7 +125,7 @@ RCT_EXPORT_METHOD(upload:(NSDictionary *)input callback:(RCTResponseSenderBlock)
   NSURL* url = [NSURL URLWithString:server];
   NSMutableURLRequest* req = [NSMutableURLRequest requestWithURL:url];
 
-  [req setHTTPMethod:@"POST"];
+  [req setHTTPMethod:HTTPMethod];
 
   NSString* formBoundaryString = @"----react.file.transfer.form.boundary";
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ var { NativeModules } = require('react-native');
 var obj = {
     uri, // either an 'assets-library' url (for files from photo library) or an image dataURL
     uploadUrl,
+    HTTPMethod, // (default="POST") type of HTTP request to use when sending (either "POST" or "PUT")
     fileName,
     fileKey, // (default="file") the name of the field in the POST form data under which to store the file
     mimeType,


### PR DESCRIPTION
This would allow users to specify the HTTP request method used. It is useful for uploading to AWS S3, as they only allow direct upload with signed links via PUT request